### PR TITLE
[Frontend] Add ability to develop from phone

### DIFF
--- a/frontend/lib/api/home_recipes_api.dart
+++ b/frontend/lib/api/home_recipes_api.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:recipe_recommender_frontend/models/recipe.dart';
 import 'package:http/http.dart' as http;
@@ -7,7 +8,8 @@ import '../models/failure.dart';
 
 class GetRecipesAPI {
   Future<List<Recipe>> getRecipes(String path) async {
-    var url = Uri.http("localhost:8080", "/$path");
+    var url = Uri.http(
+        "${const String.fromEnvironment("BrainFoodBackendIP")}:8080", "/$path");
     var response = await http.get(url);
 
     if (response.statusCode == 200) {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:recipe_recommender_frontend/screens/sign/signin.dart';
 import 'screens/nav/bottom_nav_screen.dart';
@@ -9,7 +11,6 @@ void main() {
       fontFamily: 'Satoshi',
       primarySwatch: Colors.blue,
       primaryColor: Colors.redAccent,
-
       textTheme: const TextTheme(
         headline1: TextStyle(
           fontFamily: 'Telma',

--- a/frontend/lib/screens/sign/signin.dart
+++ b/frontend/lib/screens/sign/signin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'dart:io';
 
 class SignInPage extends StatefulWidget {
   static String routeName = "/signin";
@@ -80,7 +81,9 @@ class _SignInPageState extends State<SignInPage> {
                         ),
                         child: const Text('Log In'),
                         onPressed: () async {
-                          var url = Uri.http("localhost:8080", "/signin");
+                          var url = Uri.http(
+                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "localhost")}:8080",
+                              "/signin");
                           var response = await http.post(url, body: {
                             "username": usernameController.text,
                             "password": passwordController.text
@@ -97,8 +100,6 @@ class _SignInPageState extends State<SignInPage> {
                   ),
                 ],
               ),
-            )
-        )
-    );
+            )));
   }
 }

--- a/frontend/lib/screens/sign/signup.dart
+++ b/frontend/lib/screens/sign/signup.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
@@ -30,7 +32,6 @@ class _SignUpPageState extends State<SignUpPage> {
           // Notice that the counter didn't reset back to zero; the application
           // is not restarted.
           primarySwatch: Colors.blue,
-
         ),
         home: Scaffold(
             appBar: AppBar(
@@ -93,7 +94,9 @@ class _SignUpPageState extends State<SignUpPage> {
                         ),
                         child: const Text('Sign up'),
                         onPressed: () async {
-                          var url = Uri.http("localhost:8080", "/signup");
+                          var url = Uri.http(
+                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "localhost")}:8080",
+                              "/signup");
                           var response = await http.post(url, body: {
                             "username": usernameController.text,
                             "email": emailController.text,
@@ -111,8 +114,6 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                 ],
               ),
-            )
-        )
-    );
+            )));
   }
 }


### PR DESCRIPTION
## Notes
- Anyone running the frontend app from an emulator shouldn't be affected by this PR.
- This is temporary until we host the backend on a cloud

## Usage
To be able to communicate with the backend while running the frontend on your phone, do the following:
- BOTH the mobile and the device running the backend should be running on the same network.
- You should set the environment variable "BrainFoodBackendIP" on running the frontend using the following command
`flutter run --dart-define=BrainFoodBackendIP=<Backend-IP>`

You should get your IPv4 address by running `ipconfig` on the cmdline.
Example: 
![IPCONFIG](https://user-images.githubusercontent.com/20494891/205521375-8fa12b52-94d3-41c1-8f14-d1739317d3c0.PNG)

Then run `flutter run --dart-define=BrainFoodBackendIP=192.168.1.226`