### PR TITLE
[BF-39] Fix Environment Variables

### DIFF
--- a/frontend/lib/api/home_recipes_api.dart
+++ b/frontend/lib/api/home_recipes_api.dart
@@ -9,8 +9,8 @@ import '../models/failure.dart';
 
 class GetRecipesAPI {
   Future<List<Recipe>> getRecipes(String path) async {
-    var url = Uri.http(
-        "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}", "/$path");
+    var url = Uri.https(
+        "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}", "/$path");
     var response = await http.get(url);
 
     if (response.statusCode == 200) {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -29,8 +29,8 @@ Future<File> getLocalFile() async {
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  var url = Uri.http(
-      "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+  var url = Uri.https(
+      "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
       "/home");
   print(url.toString());
   getLocalFile()
@@ -48,8 +48,8 @@ void main() {
 
 Future<String?> getServerInitResponse() async {
   session.cookie = cookieStr;
-  var url = Uri.http(
-      "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+  var url = Uri.https(
+      "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
       "/home");
   var serverResponse = await http.get(url, headers: {
     "cookie": session.cookie,

--- a/frontend/lib/screens/settings/settings.dart
+++ b/frontend/lib/screens/settings/settings.dart
@@ -16,8 +16,8 @@ class SettingsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
         onPressed: () async {
-          var url = Uri.http(
-              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+          var url = Uri.https(
+              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
               "/signout");
           debugPrint(session.cookie);
           var response =

--- a/frontend/lib/screens/sign/signin.dart
+++ b/frontend/lib/screens/sign/signin.dart
@@ -79,8 +79,8 @@ class _SignInPageState extends State<SignInPage> {
                         ),
                         child: const Text('Sign in'),
                         onPressed: () async {
-                          var url = Uri.http(
-                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+                          var url = Uri.https(
+                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
                               "/signin");
                           var response = await http.post(url, body: {
                             "username": usernameController.text,
@@ -100,15 +100,15 @@ class _SignInPageState extends State<SignInPage> {
                           debugPrint(cookie);
                           debugPrint(responseLocation);
                           debugPrint(
-                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}/signin?error");
+                              "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}/signin?error");
                           if (responseLocation ==
-                              "http://${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}/signin?error") {
+                              "https://${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}/signin?error") {
                             setState(() {
                               resp = "Wrong Credentials";
                             });
                           }
                           if (responseLocation ==
-                                  "http://${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}/home" &&
+                                  "https://${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}/home" &&
                               cookie != null) {
                             {
                               session.cookie = cookie;
@@ -117,8 +117,8 @@ class _SignInPageState extends State<SignInPage> {
                                     .writeAsString(session.cookie);
                               }
 
-                              var urlHome = Uri.http(
-                                  "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+                              var urlHome = Uri.https(
+                                  "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
                                   "/home");
                               var responseHome = await http.post(url, headers: {
                                 "cookie": cookie,

--- a/frontend/lib/screens/sign/signup.dart
+++ b/frontend/lib/screens/sign/signup.dart
@@ -94,8 +94,8 @@ class _SignUpPageState extends State<SignUpPage> {
                           bool emailValid =
                               EmailValidator.validate(emailController.text);
                           if (emailValid) {
-                            var url = Uri.http(
-                                "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "http://brainfood.azurewebsites.net")}",
+                            var url = Uri.https(
+                                "${const String.fromEnvironment("BrainFoodBackendIP", defaultValue: "brainfood.azurewebsites.net")}",
                                 "/signup");
                             var creds = {
                               "username": usernameController.text,


### PR DESCRIPTION
## Changes
Now whenever anyone try to build and run the frontend using the command `flutter run --dart-define=BrainFoodBackendIP=xxx`, he MUST provide the port if the backend is running **locally**.

### Example:
Previously: `flutter run --dart-define=BrainFoodBackendIP=192.168.1.90`

Now (locally): `flutter run --dart-define=BrainFoodBackendIP=192.168.1.90:8080`
Now (test cloud env): `flutter run --dart-define=BrainFoodBackendIP=brainfood-test.azurewebsites.net`
Now (prod cloud env): `flutter run --dart-define=BrainFoodBackendIP=brainfood.azurewebsites.net`

## Note 1:
Since the server is no hosted on the cloud, it currently uses https, so any future requests in the frontend should be made using `Uri.https(...)` instead of `Uri.http(...)`.

## Note 2:
When supplying the link to --dart-define, **DO NOT** type the `https://` part, it is handled internally.

## Note 3:
If no --dart-define is used, the frontend default is to direct its requests to the production cloud environment
ex: `flutter run`